### PR TITLE
Add coverage to CI and drop the prerelease matrix entry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - 'pre'
         os:
           - ubuntu-latest
         arch:
@@ -38,3 +37,13 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      # Upload is non-fatal on purpose: no CODECOV_TOKEN is configured for this
+      # repository yet, so this step is a no-op until one is added. Failing the
+      # build over a missing coverage upload would make CI red for a reason that
+      # has nothing to do with the code.
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
Closes #8. Part of #3.

## CI is now live

It had never executed a run — the workflows existed only on this branch, so GitHub had never registered them. Opening the PRs for #4, #5 and #7 registered the workflow and produced this repository's **first three CI runs**.

| Job | Result |
|---|---|
| Julia 1.10 - ubuntu-latest | ✅ success |
| Julia pre - ubuntu-latest | ❌ 2 failures — see below |

## Changes

**Coverage** processing and upload added. The upload is **deliberately non-fatal**: no `CODECOV_TOKEN` is configured, so the step no-ops until one is added. Failing the build over a missing coverage upload would make CI red for a reason unrelated to the code. Add the secret and it starts reporting with no further change.

**Prerelease removed from the matrix**, at your direction. The matrix now targets only `1.10` — the series named in the compat bound. This deviates from the issue as written, which retained `pre` as a non-blocking early-warning signal.

No matrix retarget was needed otherwise: `julia = "1.10"` and the matrix already agreed, exactly as the revised issue predicted.

## What the first run found

Real, and worth reading even though it no longer gates anything:

```
4×3 Grid Divergence: Test Failed at src/fluid/fvm_operators.jl:298
  Expression: divergence * v == zeros(grid.n_cell - 4)
   Evaluated: [-2.7755575615628914e-17, ...] == [0.0, ...]
```

The assertion demands **exact floating-point equality**. The residual is ~`eps()/8` — zero to machine precision. The operators are correct; the assertion isn't. Julia 1.10.11 happens to produce bitwise zeros, 1.13.0-rc2 associates the summation differently and leaves one ulp.

Filed as #13 rather than fixed here: choosing the right tolerance is a domain judgement, and this slice's constraints say not to weaken tests to make a runner green.

**Note that dropping `pre` means this stops surfacing in CI but does not stop existing.** `julia = "1.10"` admits everything below 2.0, so anyone running the suite on a newer Julia still hits it.

## Verification

Julia 1.10 on ubuntu passed on all three runs. `CI.yml` parses; matrix resolves to `["1.10"]`; 7 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)