### PR TITLE
Remove load-time filesystem side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # the test and examples manifests were tracked.
 Manifest*.toml
 
+# Example output. The library writes nothing itself; examples/common.jl puts
+# figures and data here unless AQUARIUM_OUTPUT redirects them.
+examples/output/
+
 # Editor and OS artifacts
 .vscode/
 .DS_Store

--- a/examples/case_studies/actuated_pendulum_integrator_comparison.jl
+++ b/examples/case_studies/actuated_pendulum_integrator_comparison.jl
@@ -1,7 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
-Pkg.develop(path=joinpath(@__DIR__,"..",".."))
-Pkg.instantiate()
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -13,8 +10,7 @@ using JLD2
 using Test
 using PGFPlotsX
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "pendulum")
-mkpath(vis_dir)
+vis_dir = visualization_dir("pendulum")
 
 #############################################################################################
 ## Helper functions for simulating pendulum with implicit-midpoint time integrator

--- a/examples/case_studies/immersed_boundary_comparison.jl
+++ b/examples/case_studies/immersed_boundary_comparison.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -7,10 +6,8 @@ using Aquarium.CairoMakie
 using Colors
 using JLD2
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "case_studies/immersed_boundary_comparison")
-data_dir = joinpath(Aquarium.DATA_DIR, "case_studies/immersed_boundary_comparison")
-mkpath(vis_dir)
-mkpath(data_dir)
+vis_dir = visualization_dir("case_studies/immersed_boundary_comparison")
+case_data_dir = data_dir("case_studies/immersed_boundary_comparison")
 
 #############################################################################################
 ## Parameters
@@ -132,7 +129,7 @@ for case in cases
     )
 
     # Save
-    save_file = joinpath(data_dir, "$(case.label).jld2")
+    save_file = joinpath(case_data_dir, "$(case.label).jld2")
     jldsave(save_file; tank, trajectories, bluff_body_state)
     println("Saved: $save_file")
 end
@@ -145,7 +142,7 @@ for case in cases
     println("\nAnimating: $(case.label)")
 
     # Load
-    save_file = joinpath(data_dir, "$(case.label).jld2")
+    save_file = joinpath(case_data_dir, "$(case.label).jld2")
     data = load(save_file)
     tank = data["tank"]
     trajectories = data["trajectories"]

--- a/examples/case_studies/pendulum_integrator_comparison.jl
+++ b/examples/case_studies/pendulum_integrator_comparison.jl
@@ -1,7 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
-Pkg.develop(path=joinpath(@__DIR__,"..",".."))
-Pkg.instantiate()
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -13,8 +10,7 @@ using JLD2
 using Test
 using PGFPlotsX
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "pendulum")
-mkpath(vis_dir)
+vis_dir = visualization_dir("pendulum")
 
 #############################################################################################
 ## Helper functions for simulating pendulum with implicit-midpoint time integrator

--- a/examples/case_studies/poiseuille_flow_grid_convergence.jl
+++ b/examples/case_studies/poiseuille_flow_grid_convergence.jl
@@ -1,7 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
-Pkg.develop(path=joinpath(@__DIR__,"..",".."))
-Pkg.instantiate()
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -11,8 +8,7 @@ using JLD2
 using Test
 using PGFPlotsX
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "poiseuille_flow")
-mkpath(vis_dir)
+vis_dir = visualization_dir("poiseuille_flow")
 
 #############################################################################################
 ## Plot parameters
@@ -106,7 +102,7 @@ fluid_sim_data_300x100 = simulate_fluid(fluid_env_300x100, fluid_velocity_0_300x
     ilu_drop_tolerance=1e-2, dual_regularization=1e-6, verbose=false
 )
 
-save_file = joinpath(Aquarium.DATA_DIR, "poiseuille_flow.jld2")
+save_file = data_file("poiseuille_flow.jld2")
 jldsave(save_file;
     fluid_sim_data_30x10,
     fluid_sim_data_150x50,
@@ -117,7 +113,7 @@ jldsave(save_file;
 ## Import sim results
 #############################################################################################
 
-data = load(joinpath(Aquarium.DATA_DIR, "poiseuille_flow.jld2"))
+data = load(data_file("poiseuille_flow.jld2"))
 fluid_sim_data_30x10 = data["fluid_sim_data_30x10"]
 fluid_sim_data_150x50 = data["fluid_sim_data_150x50"]
 fluid_sim_data_300x100 = data["fluid_sim_data_300x100"]

--- a/examples/common.jl
+++ b/examples/common.jl
@@ -1,0 +1,66 @@
+# Shared setup for Aquarium's example scripts.
+#
+# Every example begins with:
+#
+#     include(joinpath(@__DIR__, "..", "common.jl"))
+#
+# which activates the examples environment and provides the output-directory
+# helpers below.
+#
+# Output location is the caller's concern, not the library's: Aquarium returns
+# figures and data and writes nothing itself (see docs/adr/0003). These helpers
+# give the examples one shared convention without putting path management back
+# into the package.
+
+import Pkg
+
+Pkg.activate(@__DIR__)
+
+# Aquarium is not registered, so a fresh clone cannot resolve it from a registry
+# and `Pkg.instantiate()` alone would fail with
+#     ERROR: expected package `Aquarium [573b866c]` to be registered
+# Develop it from the repository root the first time, when no resolved
+# environment exists yet. Once Aquarium is registered this block becomes
+# unnecessary, though developing the local checkout is still the right thing for
+# examples that live inside the repository -- they should exercise the working
+# tree, not a released version.
+if !isfile(joinpath(@__DIR__, "Manifest.toml"))
+    Pkg.develop(Pkg.PackageSpec(path = normpath(joinpath(@__DIR__, ".."))))
+end
+
+Pkg.instantiate()
+
+"""
+Root directory for everything the examples write.
+
+Set `AQUARIUM_OUTPUT` to redirect it; otherwise output lands in `examples/output`,
+which is ignored by version control.
+"""
+const OUTPUT_ROOT = get(ENV, "AQUARIUM_OUTPUT", joinpath(@__DIR__, "output"))
+
+_ensure_dir(path) = (mkpath(path); path)
+
+"""
+    visualization_dir(parts...)
+
+Directory for figures and animations, created if absent.
+"""
+visualization_dir(parts...) = _ensure_dir(joinpath(OUTPUT_ROOT, "visualization", parts...))
+
+"""
+    data_dir(parts...)
+
+Directory for saved simulation data, created if absent.
+"""
+data_dir(parts...) = _ensure_dir(joinpath(OUTPUT_ROOT, "data", parts...))
+
+"""
+    data_file(parts...)
+
+Path to a file under the data directory. The containing directory is created;
+the file itself is not.
+"""
+function data_file(parts...)
+    _ensure_dir(joinpath(OUTPUT_ROOT, "data", parts[1:end-1]...))
+    return joinpath(OUTPUT_ROOT, "data", parts...)
+end

--- a/examples/fluid_examples/freestream_disc_example.jl
+++ b/examples/fluid_examples/freestream_disc_example.jl
@@ -1,7 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
-Pkg.develop(path=joinpath(@__DIR__,"..",".."))
-Pkg.instantiate()
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -10,8 +7,7 @@ using Colors
 using JLD2
 using LsqFit
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "freestream_disc")
-mkpath(vis_dir)
+vis_dir = visualization_dir("freestream_disc")
 
 #############################################################################################
 ## Plot parameters
@@ -156,7 +152,7 @@ trajectories = simulate_aquarium(
 println("\nSimulation complete!")
 
 # Save simulation data
-save_file = joinpath(Aquarium.DATA_DIR, "freestream_disc_$(floor(Int, reynolds_number))re.jld2")
+save_file = data_file("freestream_disc_$(floor(Int, reynolds_number))re.jld2")
 jldsave(save_file; tank, trajectories)
 println("\nResults saved to: ", save_file)
 
@@ -164,7 +160,7 @@ println("\nResults saved to: ", save_file)
 ## Load sim results
 #############################################################################################
 
-save_file = joinpath(Aquarium.DATA_DIR, "freestream_disc_$(floor(Int, reynolds_number))re.jld2")
+save_file = data_file("freestream_disc_$(floor(Int, reynolds_number))re.jld2")
 data = load(save_file)
 
 tank = data[:"tank"]

--- a/examples/fluid_examples/lid_cavity_flow_example.jl
+++ b/examples/fluid_examples/lid_cavity_flow_example.jl
@@ -1,7 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
-Pkg.develop(path=joinpath(@__DIR__,"..",".."))
-Pkg.instantiate()
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -11,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "lid_cavity_flow")
-mkpath(vis_dir)
+vis_dir = visualization_dir("lid_cavity_flow")
 
 #############################################################################################
 ## Plot parameters
@@ -81,7 +77,7 @@ fluid_sim_data = simulate_fluid(fluid_env, fluid_state_0, final_time;
     lazy=true, verbose=false
 )
 
-save_file = joinpath(Aquarium.DATA_DIR, "lid_cavity_flow.jld2")
+save_file = data_file("lid_cavity_flow.jld2")
 jldsave(save_file;
     fluid_sim_data
 );
@@ -90,7 +86,7 @@ jldsave(save_file;
 ## Import sim results
 #############################################################################################
 
-data = load(joinpath(Aquarium.DATA_DIR, "lid_cavity_flow.jld2"))
+data = load(data_file("lid_cavity_flow.jld2"))
 fluid_sim_data = data["fluid_sim_data"]
 t_traj = fluid_sim_data[:t_traj]
 fluid_velocity_traj = fluid_sim_data[:fluid_velocity_traj]

--- a/examples/fsi_examples/rexeel_c_start.jl
+++ b/examples/fsi_examples/rexeel_c_start.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -10,8 +9,7 @@ using JLD2
 using Test
 using Random
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "rexeel_c_start")
-mkpath(vis_dir)
+vis_dir = visualization_dir("rexeel_c_start")
 
 #############################################################################################
 ## Plot params
@@ -460,7 +458,7 @@ trajectories = simulate_aquarium(
 println("\nSimulation complete!")
 
 # Save simulation data
-save_file = joinpath(Aquarium.DATA_DIR, "rexeel_c_start.jld2")
+save_file = data_file("rexeel_c_start.jld2")
 jldsave(save_file; trajectories)
 println("Results saved to: ", save_file)
 println()
@@ -471,7 +469,7 @@ println()
 
 # Load simulation data
 
-load_file = joinpath(Aquarium.DATA_DIR, "rexeel_c_start.jld2")
+load_file = data_file("rexeel_c_start.jld2")
 data = load(load_file)
 trajectories = data["trajectories"]
 

--- a/examples/fsi_examples/rexeel_forward_swimming.jl
+++ b/examples/fsi_examples/rexeel_forward_swimming.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "rexeel_forward_swimming")
-mkpath(vis_dir)
+vis_dir = visualization_dir("rexeel_forward_swimming")
 
 #############################################################################################
 ## Plot params
@@ -429,7 +427,7 @@ trajectories = simulate_aquarium(
 println("\nSimulation complete!")
 
 # Save simulation data
-save_file = joinpath(Aquarium.DATA_DIR, "rexeel_forward_swimming.jld2")
+save_file = data_file("rexeel_forward_swimming.jld2")
 jldsave(save_file; trajectories)
 println("Results saved to: ", save_file)
 println()
@@ -439,7 +437,7 @@ println()
 #############################################################################################
 
 # Load simulation data
-load_file = joinpath(Aquarium.DATA_DIR, "rexeel_forward_swimming.jld2")
+load_file = data_file("rexeel_forward_swimming.jld2")
 data = load(load_file)
 trajectories = data["trajectories"]
 

--- a/examples/solid_examples/actuated_pendulum_example.jl
+++ b/examples/solid_examples/actuated_pendulum_example.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "actuated_pendulum")
-mkpath(vis_dir)
+vis_dir = visualization_dir("actuated_pendulum")
 
 #############################################################################################
 ## Plot params

--- a/examples/solid_examples/double_pendulum_example.jl
+++ b/examples/solid_examples/double_pendulum_example.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "double_pendulum")
-mkpath(vis_dir)
+vis_dir = visualization_dir("double_pendulum")
 
 #############################################################################################
 ## Plot params

--- a/examples/solid_examples/eel_example.jl
+++ b/examples/solid_examples/eel_example.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "eel")
-mkpath(vis_dir)
+vis_dir = visualization_dir("eel")
 
 #############################################################################################
 ## Plot params

--- a/examples/solid_examples/pendulum_example.jl
+++ b/examples/solid_examples/pendulum_example.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "pendulum")
-mkpath(vis_dir)
+vis_dir = visualization_dir("pendulum")
 
 #############################################################################################
 ## Plot params

--- a/examples/solid_examples/rexeel_example.jl
+++ b/examples/solid_examples/rexeel_example.jl
@@ -1,5 +1,4 @@
-import Pkg
-Pkg.activate(joinpath(@__DIR__,".."))
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 using Aquarium
 using Aquarium.LinearAlgebra
@@ -9,8 +8,7 @@ using Colors
 using JLD2
 using Test
 
-vis_dir = joinpath(Aquarium.VIS_DIR, "rexeel")
-mkpath(vis_dir)
+vis_dir = visualization_dir("rexeel")
 
 #############################################################################################
 ## Plot params

--- a/src/Aquarium.jl
+++ b/src/Aquarium.jl
@@ -127,15 +127,10 @@ include("visualization/aquarium_animations.jl")
 ## Export all functions
 @exportAll()
 
-## Define directory paths
-const EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
-const TEST_DIR = joinpath(@__DIR__, "..", "test")
-const VIS_DIR = expanduser(joinpath("~/aquarium", "visualization"))
-const DATA_DIR = expanduser(joinpath("~/aquarium", "data"))
-
-mkpath(EXAMPLES_DIR)
-mkpath(TEST_DIR)
-mkpath(VIS_DIR)
-mkpath(DATA_DIR)
+# Aquarium owns no filesystem paths and creates no directories on load. It
+# returns figures and data; where they go is the caller's decision. See
+# docs/adr/0003-library-owns-no-filesystem-paths.md -- in particular, two of the
+# directory constants that used to live here targeted the package's own source
+# tree, which is read-only for any registry install.
 
 end

--- a/test/example_smoke_tests.jl
+++ b/test/example_smoke_tests.jl
@@ -1,0 +1,41 @@
+@testitem "Example scripts parse and use the shared output helpers" begin
+    using Test
+
+    # Nothing in the suite runs the example scripts -- they take minutes each and
+    # need a display. That makes them the weakest-verified surface in the
+    # repository: all thirteen can be edited wrongly while the suite stays green.
+    #
+    # This is a floor, not proof. It catches syntax damage and stale references to
+    # the removed path constants, which is the failure mode a bulk edit actually
+    # produces. It does not catch a script that parses fine and computes the wrong
+    # thing.
+
+    examples_root = joinpath(pkgdir(Aquarium), "examples")
+    scripts = String[]
+    for (dir, _, files) in walkdir(examples_root), file in files
+        endswith(file, ".jl") && file != "common.jl" && push!(scripts, joinpath(dir, file))
+    end
+
+    @test length(scripts) == 13
+
+    for script in scripts
+        source = read(script, String)
+        rel = relpath(script, examples_root)
+
+        @testset "$rel" begin
+            # Parses as valid Julia.
+            parsed = Meta.parseall(source; filename = script)
+            @test !any(x -> x isa Expr && x.head === :error, parsed.args)
+
+            # Uses the shared setup rather than its own environment handling.
+            @test occursin("common.jl", source)
+            @test !occursin(r"^\s*Pkg\."m, source)
+
+            # References no constant the library no longer defines.
+            for removed in ("Aquarium.VIS_DIR", "Aquarium.DATA_DIR",
+                            "Aquarium.EXAMPLES_DIR", "Aquarium.TEST_DIR")
+                @test !occursin(removed, source)
+            end
+        end
+    end
+end

--- a/test/load_side_effect_tests.jl
+++ b/test/load_side_effect_tests.jl
@@ -1,0 +1,37 @@
+@testitem "Loading Aquarium writes nothing to the user's home directory" begin
+    using Aquarium
+
+    # The naive form of this test -- assert ~/aquarium does not exist -- is
+    # useless in both directions. It passes vacuously on a machine that never ran
+    # the old code, and fails spuriously on a developer machine where an earlier
+    # run already created the directory. Neither outcome says anything about the
+    # current code.
+    #
+    # Load the package in a subprocess with HOME pointed at an empty temporary
+    # directory, then assert that directory is still empty. JULIA_DEPOT_PATH is
+    # passed through explicitly: the depot is derived from HOME by default, so
+    # without this the subprocess would populate the fake home with a .julia
+    # directory and the test would fail for reasons unrelated to Aquarium.
+    mktempdir() do fake_home
+        env = copy(ENV)
+        env["HOME"] = fake_home
+        env["JULIA_DEPOT_PATH"] = join(DEPOT_PATH, Sys.iswindows() ? ';' : ':')
+
+        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e "using Aquarium"`
+        @test success(run(setenv(cmd, env); wait = true))
+
+        @test isempty(readdir(fake_home))
+    end
+end
+
+@testitem "Aquarium exposes no filesystem-path constants" begin
+    using Aquarium
+
+    # These four constants were removed along with the mkpath calls that ran at
+    # module scope. Two of them pointed into the package's own source tree, which
+    # is read-only for any registry install -- see docs/adr/0003. Asserting their
+    # absence keeps a future contributor from reintroducing the convenience.
+    for name in (:VIS_DIR, :DATA_DIR, :EXAMPLES_DIR, :TEST_DIR)
+        @test !isdefined(Aquarium, name)
+    end
+end


### PR DESCRIPTION
Closes #6. Part of #3. **HITL — ready for review, not auto-merged.**

## The install blocker

Importing Aquarium created directories. Four constants and four module-scope `mkpath` calls meant `using Aquarium` created `~/aquarium/visualization` and `~/aquarium/data`, and attempted to create two more *inside the package's own source tree* — read-only for any registry install, which is the normal case in CI, on clusters, and for every user not developing the package.

All four constants and all four `mkpath` calls are gone.

## `examples/common.jl`

New, and owns what the library gave up: activates the examples environment and provides `visualization_dir`, `data_dir`, `data_file`, rooted at `AQUARIUM_OUTPUT` and defaulting to a gitignored `examples/output/`.

It also **bridges the problem inherited from #7**. With `examples/Manifest.toml` untracked, the examples environment can't resolve Aquarium from a registry, because Aquarium is unregistered:

```
ERROR: expected package `Aquarium [573b866c]` to be registered
```

`common.jl` develops the repository root when no resolved environment exists yet. After registration that stops being necessary — though developing the local checkout stays right for examples living inside the repo, since they should exercise the working tree rather than a released version.

All 13 example scripts now open with the shared include. Five carried *extra* `Pkg.develop`/`Pkg.instantiate` lines beyond the standard two; gone as well.

## Two things the plan didn't anticipate

**A name collision.** `immersed_boundary_comparison.jl` used `data_dir` as a local variable, shadowing the helper. Renamed to `case_data_dir` — one file, four lines.

**The obvious test would have been worthless.** Asserting `~/aquarium` doesn't exist passes vacuously on a clean machine and fails spuriously on the author's, where prior runs already created it — neither outcome says anything about the code. The real test loads Aquarium in a subprocess with `HOME` pointed at an empty temp dir and asserts it stays empty. `JULIA_DEPOT_PATH` is passed through explicitly, because the depot is derived from `HOME` and the subprocess would otherwise populate the fake home with a `.julia` directory and fail for unrelated reasons.

## What reviewers should look at

This slice was flagged as having the **weakest verification oracle** in the phase, and that hasn't changed. Nothing in the suite runs the example scripts, so all 13 could be edited wrongly while the suite stays green. Per instruction, **no example was executed**.

The smoke test is framed as a floor, not proof: it checks each script parses, uses the shared setup, and references no removed constant — the failure modes a bulk regex edit actually produces. It cannot catch a script that parses fine and computes the wrong thing. **The example edits themselves want human eyes.**

## Verification

```
Pkg.test() → 2326 passed, 0 failed, 4m19.0s
```

Up from 2228; the 98 new passes are the side-effect and smoke suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)