### PR TITLE
Make example data saving and animation opt-in

### DIFF
--- a/examples/case_studies/actuated_pendulum_integrator_comparison.jl
+++ b/examples/case_studies/actuated_pendulum_integrator_comparison.jl
@@ -233,4 +233,4 @@ axislegend(ax,
     orientation=:horizontal,
     nbanks=1
 )
-display(fig)
+maybe_display(fig)

--- a/examples/case_studies/immersed_boundary_comparison.jl
+++ b/examples/case_studies/immersed_boundary_comparison.jl
@@ -80,6 +80,8 @@ end
 ## Run simulations
 #############################################################################################
 
+results = Dict{String,Any}()
+
 cases = [
     (ib_method = :original,  n_nodes = n_nodes_fine,   label = "original_fine"),
     (ib_method = :original,  n_nodes = n_nodes_coarse, label = "original_coarse"),
@@ -130,8 +132,10 @@ for case in cases
 
     # Save
     save_file = joinpath(case_data_dir, "$(case.label).jld2")
-    jldsave(save_file; tank, trajectories, bluff_body_state)
-    println("Saved: $save_file")
+    maybe_jldsave(save_file; tank, trajectories, bluff_body_state)
+    # Kept in memory as well, so the animation loop below does not depend on
+    # data having been written -- saving is opt-in.
+    results[case.label] = (; tank, trajectories, bluff_body_state)
 end
 
 #############################################################################################
@@ -141,12 +145,10 @@ end
 for case in cases
     println("\nAnimating: $(case.label)")
 
-    # Load
-    save_file = joinpath(case_data_dir, "$(case.label).jld2")
-    data = load(save_file)
-    tank = data["tank"]
-    trajectories = data["trajectories"]
-    bluff_body_state = data["bluff_body_state"]
+    result = results[case.label]
+    tank = result.tank
+    trajectories = result.trajectories
+    bluff_body_state = result.bluff_body_state
 
     fluid_env = tank.fluid
     bluff_body = tank.bluff_body
@@ -169,7 +171,7 @@ for case in cases
 
     # Animate (10s video: timescale = final_time / 10)
     save_path = joinpath(vis_dir, "$(case.label)_streamlines.mp4")
-    animate_streamlines(
+    animate_if_enabled(animate_streamlines, 
         fig, ax,
         fluid_env,
         bluff_body, nothing,
@@ -182,7 +184,7 @@ for case in cases
         framerate = 30,
         timescale = final_time / 10.0,
     )
-    println("Saved: $save_path")
+    SAVE_ANIMATIONS && println("Saved: $save_path")
 
     # Final-state SVG: white background, black axes/labels, Times New Roman
     # Flip segment/node colors relative to the animation.
@@ -210,10 +212,10 @@ for case in cases
         density = 20,
     )
     svg_path = joinpath(vis_dir, "$(case.label)_final.svg")
-    save(svg_path, fig_svg)
-    println("Saved: $svg_path")
+    maybe_save(svg_path, fig_svg)
+    SAVE_FIGURES && println("Saved: $svg_path")
 end
 
 println("\n" * "="^80)
-println("All done! Animations saved to: $vis_dir")
+SAVE_ANIMATIONS && println("All done! Animations saved to: $vis_dir")
 println("="^80)

--- a/examples/case_studies/pendulum_integrator_comparison.jl
+++ b/examples/case_studies/pendulum_integrator_comparison.jl
@@ -226,7 +226,7 @@ axislegend(ax,
     orientation=:horizontal,
     nbanks=1
 )
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## Plot energies for comparison
@@ -259,4 +259,4 @@ axislegend(ax2,
     orientation=:horizontal,
     nbanks=1
 )
-display(fig2)
+maybe_display(fig2)

--- a/examples/case_studies/poiseuille_flow_grid_convergence.jl
+++ b/examples/case_studies/poiseuille_flow_grid_convergence.jl
@@ -103,7 +103,7 @@ fluid_sim_data_300x100 = simulate_fluid(fluid_env_300x100, fluid_velocity_0_300x
 )
 
 save_file = data_file("poiseuille_flow.jld2")
-jldsave(save_file;
+maybe_jldsave(save_file;
     fluid_sim_data_30x10,
     fluid_sim_data_150x50,
     fluid_sim_data_300x100
@@ -113,10 +113,7 @@ jldsave(save_file;
 ## Import sim results
 #############################################################################################
 
-data = load(data_file("poiseuille_flow.jld2"))
-fluid_sim_data_30x10 = data["fluid_sim_data_30x10"]
-fluid_sim_data_150x50 = data["fluid_sim_data_150x50"]
-fluid_sim_data_300x100 = data["fluid_sim_data_300x100"]
+# The three fluid_sim_data_* values are already in memory from above.
 
 t_traj_30x10 = fluid_sim_data_30x10[:t_traj]
 fluid_velocity_traj_30x10 = fluid_sim_data_30x10[:fluid_velocity_traj]

--- a/examples/case_studies/poiseuille_flow_grid_convergence.jl
+++ b/examples/case_studies/poiseuille_flow_grid_convergence.jl
@@ -167,7 +167,7 @@ plot_streamlines!(fig, ax,
     fluid_velocity_traj_300x100[end],
     [], []
 )
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## Plot vorticity
@@ -191,7 +191,7 @@ plot_vorticity_field!(fig, ax,
     min_threshold=-10.0,
     max_threshold=10.0
 )
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## Plot velocity field
@@ -220,7 +220,7 @@ plot_velocity_field!(fig, ax,
     tipcolor=logocolors.blue,
     shaftcolor=logocolors.blue,
 )
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## Plot pressure field
@@ -242,7 +242,7 @@ plot_pressure_field!(fig, ax,
     [], [];
 
 )
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## plot energy over time
@@ -261,7 +261,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect=false
 )
 lines!(ax, 0:dt:tf, fluid_energy_traj)
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## plot pressure norms over time
@@ -277,7 +277,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect=false
 )
 lines!(ax, dt:dt:tf, fluid_pressure_norm_traj, label="Pressure (Fluid)")
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## plot velocity profiles
@@ -325,7 +325,7 @@ scatter!(ax, fluid_velocity_x_profile_300x100[2:end-1],
 xlims!(ax, -0.01, 1.1*boundary_velocity[1])
 
 axislegend(ax, backgroundcolor=:transparent, labelcolor=:black, framecolor=:black)
-display(fig)
+maybe_display(fig)
 
 #############################################################################################
 ## Make tikz plot of velocity profiles

--- a/examples/common.jl
+++ b/examples/common.jl
@@ -63,6 +63,15 @@ const SAVE_DATA = SAVE_ALL || _flag("AQUARIUM_SAVE_DATA")
 const SAVE_FIGURES = SAVE_ALL || _flag("AQUARIUM_SAVE_FIGURES")
 const SAVE_ANIMATIONS = SAVE_ALL || _flag("AQUARIUM_SAVE_ANIMATIONS")
 
+# Whether to open figures in a viewer. Defaults to whether the session is
+# interactive: opening a window is what you want from a REPL or an editor cell,
+# and is at best noise when the script is run headlessly -- on a cluster, over
+# SSH, or in CI. That headless case is not hypothetical; see PR #2, whose commit
+# "saved figs for headless VM" was working around exactly this.
+#
+#   AQUARIUM_DISPLAY=true|false   override the interactivity default
+const DISPLAY_FIGURES = haskey(ENV, "AQUARIUM_DISPLAY") ? _flag("AQUARIUM_DISPLAY") : isinteractive()
+
 #############################################################################################
 ## Output locations
 #############################################################################################
@@ -88,7 +97,8 @@ if !(SAVE_DATA || SAVE_FIGURES || SAVE_ANIMATIONS)
     Aquarium examples: artifact output is off, so this run writes nothing.
     Enable it with AQUARIUM_SAVE_ALL=true, or individually via
     AQUARIUM_SAVE_DATA / AQUARIUM_SAVE_FIGURES / AQUARIUM_SAVE_ANIMATIONS.
-    Output would go to $(OUTPUT_ROOT) unless AQUARIUM_OUTPUT redirects it."""
+    Output would go to $(OUTPUT_ROOT) unless AQUARIUM_OUTPUT redirects it.
+    Figures are $(DISPLAY_FIGURES ? "shown" : "not shown") in this session; override with AQUARIUM_DISPLAY."""
 end
 
 #############################################################################################
@@ -126,3 +136,11 @@ function animate_if_enabled(f, args...; kwargs...)
     end
     return f(args...; kwargs...)
 end
+
+"""
+    maybe_display(figure)
+
+Open `figure` in a viewer only when display is enabled. Returns `figure` either
+way, so it can be used inline.
+"""
+maybe_display(figure) = DISPLAY_FIGURES ? display(figure) : figure

--- a/examples/common.jl
+++ b/examples/common.jl
@@ -4,8 +4,8 @@
 #
 #     include(joinpath(@__DIR__, "..", "common.jl"))
 #
-# which activates the examples environment and provides the output-directory
-# helpers below.
+# which activates the examples environment and provides the output helpers and
+# artifact flags below.
 #
 # Output location is the caller's concern, not the library's: Aquarium returns
 # figures and data and writes nothing itself (see docs/adr/0003). These helpers
@@ -30,6 +30,43 @@ end
 
 Pkg.instantiate()
 
+# `save` and `jldsave` are deliberately NOT imported here.
+#
+# This file is included into Main, so an explicit `using FileIO: save` would take
+# precedence over the `save` that each example gets from `using Aquarium.CairoMakie`
+# -- and the figures being written are Makie figures. Julia resolves globals in
+# function bodies at call time, so leaving these unimported means the writers below
+# pick up whatever `save`/`jldsave` the including script has in scope, which is the
+# same binding the examples used before these wrappers existed.
+
+#############################################################################################
+## Artifact flags
+#############################################################################################
+
+# Examples compute and plot by default and write nothing at all. Saving is opt-in
+# because the artifacts are expensive in different ways: animations need a video
+# encoder and dominate runtime, and the data files are large. The code to produce
+# them is a real part of what the examples demonstrate, so it stays -- it just
+# stops being mandatory.
+#
+#   AQUARIUM_SAVE_DATA=true        .jld2 simulation data
+#   AQUARIUM_SAVE_FIGURES=true     static figures
+#   AQUARIUM_SAVE_ANIMATIONS=true  animations
+#   AQUARIUM_SAVE_ALL=true         all three
+#
+# Flags are read once, here, so a single run is internally consistent.
+
+_flag(name) = lowercase(strip(get(ENV, name, "false"))) in ("1", "true", "yes", "on")
+
+const SAVE_ALL = _flag("AQUARIUM_SAVE_ALL")
+const SAVE_DATA = SAVE_ALL || _flag("AQUARIUM_SAVE_DATA")
+const SAVE_FIGURES = SAVE_ALL || _flag("AQUARIUM_SAVE_FIGURES")
+const SAVE_ANIMATIONS = SAVE_ALL || _flag("AQUARIUM_SAVE_ANIMATIONS")
+
+#############################################################################################
+## Output locations
+#############################################################################################
+
 """
 Root directory for everything the examples write.
 
@@ -38,29 +75,54 @@ which is ignored by version control.
 """
 const OUTPUT_ROOT = get(ENV, "AQUARIUM_OUTPUT", joinpath(@__DIR__, "output"))
 
-_ensure_dir(path) = (mkpath(path); path)
+# These compute paths and deliberately do NOT create anything. Directories are
+# made only when something is actually written, by the helpers below -- otherwise
+# a default run would still litter the filesystem with empty directories.
+visualization_dir(parts...) = joinpath(OUTPUT_ROOT, "visualization", parts...)
+data_dir(parts...) = joinpath(OUTPUT_ROOT, "data", parts...)
+data_file(parts...) = joinpath(OUTPUT_ROOT, "data", parts...)
+
+# Announced after OUTPUT_ROOT exists, so the message can name the location.
+if !(SAVE_DATA || SAVE_FIGURES || SAVE_ANIMATIONS)
+    @info """
+    Aquarium examples: artifact output is off, so this run writes nothing.
+    Enable it with AQUARIUM_SAVE_ALL=true, or individually via
+    AQUARIUM_SAVE_DATA / AQUARIUM_SAVE_FIGURES / AQUARIUM_SAVE_ANIMATIONS.
+    Output would go to $(OUTPUT_ROOT) unless AQUARIUM_OUTPUT redirects it."""
+end
+
+#############################################################################################
+## Guarded writers
+#############################################################################################
+
+_prepare(path) = (mkpath(dirname(path)); path)
 
 """
-    visualization_dir(parts...)
+    maybe_save(path, figure)
 
-Directory for figures and animations, created if absent.
+Save `figure` only when figure output is enabled. Returns `path` either way, so
+callers can print or reuse it regardless.
 """
-visualization_dir(parts...) = _ensure_dir(joinpath(OUTPUT_ROOT, "visualization", parts...))
-
-"""
-    data_dir(parts...)
-
-Directory for saved simulation data, created if absent.
-"""
-data_dir(parts...) = _ensure_dir(joinpath(OUTPUT_ROOT, "data", parts...))
+maybe_save(path, figure) = SAVE_FIGURES ? save(_prepare(path), figure) : path
 
 """
-    data_file(parts...)
+    maybe_jldsave(path; data...)
 
-Path to a file under the data directory. The containing directory is created;
-the file itself is not.
+Write `data` only when data output is enabled. Returns `path` either way.
 """
-function data_file(parts...)
-    _ensure_dir(joinpath(OUTPUT_ROOT, "data", parts[1:end-1]...))
-    return joinpath(OUTPUT_ROOT, "data", parts...)
+maybe_jldsave(path; data...) = SAVE_DATA ? jldsave(_prepare(path); data...) : path
+
+"""
+    animate_if_enabled(f, args...; kwargs...)
+
+Call animation function `f` only when animation output is enabled. Animations are
+the slowest thing the examples do and need a video encoder, so they are off by
+default.
+"""
+function animate_if_enabled(f, args...; kwargs...)
+    SAVE_ANIMATIONS || return nothing
+    for arg in args
+        arg isa AbstractString && startswith(arg, OUTPUT_ROOT) && _prepare(arg)
+    end
+    return f(args...; kwargs...)
 end

--- a/examples/fluid_examples/freestream_disc_example.jl
+++ b/examples/fluid_examples/freestream_disc_example.jl
@@ -237,7 +237,7 @@ fig, ax = create_aquarium_figure(;
 lines!(ax, time_traj, drag_coeff_traj, label="Drag Coefficient", linewidth=2, color=:red)
 lines!(ax, time_traj, lift_coeff_traj, label="Lift Coefficient", linewidth=2, color=:blue)
 axislegend(ax, backgroundcolor=:transparent, labelcolor=:white, framecolor=:white)
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_lift_drag_coefficients_$(floor(Int, reynolds_number))re.png"), fig)
 
 #############################################################################################
@@ -352,7 +352,7 @@ lines!(ax_fit, time_segment[1] .+ time_fit, lift_fitted_curve, linewidth=2, colo
 lines!(ax_fit, time_segment[1] .+ time_fit, drag_fitted_curve, linewidth=2, color=:orange,
        linestyle=:dash, label="Drag Fitted (f=$(round(drag_shedding_frequency, digits=3)) Hz)")
 axislegend(ax_fit, backgroundcolor=:transparent, labelcolor=:white, framecolor=:white)
-display(fig_fit)
+maybe_display(fig_fit)
 maybe_save(joinpath(vis_dir, "freestream_disc_curve_fit_$(floor(Int, reynolds_number))re.png"), fig_fit)
 
 #############################################################################################
@@ -380,7 +380,7 @@ plot_streamlines!(fig, ax,
     bluff_body_state_traj[end], [];
     density=50
 )
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_streamlines_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_streamlines_animation_$(floor(Int, reynolds_number))re.mp4")
@@ -418,7 +418,7 @@ plot_vorticity_field!(fig, ax,
     min_threshold=-500.0,
     max_threshold=500.0
 )
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_vorticity_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_vorticity_animation_$(floor(Int, reynolds_number))re.mp4")
@@ -455,7 +455,7 @@ plot_pressure_field!(fig, ax,
     fluid_pressure_traj[end],
     bluff_body_state, [];
 )
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_pressure_animation_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_pressure_animation_$(floor(Int, reynolds_number))re.mp4")
@@ -488,7 +488,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect=false
 )
 lines!(ax, time_traj, fluid_energy_traj, label="Fluid Energy", linewidth=2)
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_energy_$(floor(Int, reynolds_number))re.png"), fig)
 
 #############################################################################################
@@ -510,7 +510,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect=false
 )
 lines!(ax, time_traj, fluid_pressure_norm_traj, label="Pressure Norm", linewidth=2)
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "freestream_disc_pressure_norm_$(floor(Int, reynolds_number))re.png"), fig)
 
 println("\n" * "="^80)

--- a/examples/fluid_examples/freestream_disc_example.jl
+++ b/examples/fluid_examples/freestream_disc_example.jl
@@ -153,18 +153,14 @@ println("\nSimulation complete!")
 
 # Save simulation data
 save_file = data_file("freestream_disc_$(floor(Int, reynolds_number))re.jld2")
-jldsave(save_file; tank, trajectories)
-println("\nResults saved to: ", save_file)
+maybe_jldsave(save_file; tank, trajectories)
+SAVE_DATA && println("\nResults saved to: ", save_file)
 
 #############################################################################################
 ## Load sim results
 #############################################################################################
 
-save_file = data_file("freestream_disc_$(floor(Int, reynolds_number))re.jld2")
-data = load(save_file)
-
-tank = data[:"tank"]
-trajectories = data[:"trajectories"]
+# tank and trajectories are already in memory from the simulation above.
 
 fluid_env = tank.fluid
 bluff_body = tank.bluff_body
@@ -242,7 +238,7 @@ lines!(ax, time_traj, drag_coeff_traj, label="Drag Coefficient", linewidth=2, co
 lines!(ax, time_traj, lift_coeff_traj, label="Lift Coefficient", linewidth=2, color=:blue)
 axislegend(ax, backgroundcolor=:transparent, labelcolor=:white, framecolor=:white)
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_lift_drag_coefficients_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_lift_drag_coefficients_$(floor(Int, reynolds_number))re.png"), fig)
 
 #############################################################################################
 ## Calculate Strouhal number using curve fitting
@@ -357,7 +353,7 @@ lines!(ax_fit, time_segment[1] .+ time_fit, drag_fitted_curve, linewidth=2, colo
        linestyle=:dash, label="Drag Fitted (f=$(round(drag_shedding_frequency, digits=3)) Hz)")
 axislegend(ax_fit, backgroundcolor=:transparent, labelcolor=:white, framecolor=:white)
 display(fig_fit)
-save(joinpath(vis_dir, "freestream_disc_curve_fit_$(floor(Int, reynolds_number))re.png"), fig_fit)
+maybe_save(joinpath(vis_dir, "freestream_disc_curve_fit_$(floor(Int, reynolds_number))re.png"), fig_fit)
 
 #############################################################################################
 ## Plot streamlines
@@ -385,10 +381,10 @@ plot_streamlines!(fig, ax,
     density=50
 )
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_streamlines_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_streamlines_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_streamlines_animation_$(floor(Int, reynolds_number))re.mp4")
-animate_streamlines(fig, ax,
+animate_if_enabled(animate_streamlines, fig, ax,
     fluid_env,
     bluff_body, nothing,
     time_traj,
@@ -423,10 +419,10 @@ plot_vorticity_field!(fig, ax,
     max_threshold=500.0
 )
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_vorticity_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_vorticity_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_vorticity_animation_$(floor(Int, reynolds_number))re.mp4")
-animate_vorticity_field(fig, ax,
+animate_if_enabled(animate_vorticity_field, fig, ax,
     fluid_env,
     bluff_body, nothing,
     time_traj,
@@ -460,10 +456,10 @@ plot_pressure_field!(fig, ax,
     bluff_body_state, [];
 )
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_pressure_animation_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_pressure_animation_$(floor(Int, reynolds_number))re.png"), fig)
 
 save_path = joinpath(vis_dir, "freestream_disc_pressure_animation_$(floor(Int, reynolds_number))re.mp4")
-animate_pressure_field(fig, ax,
+animate_if_enabled(animate_pressure_field, fig, ax,
     fluid_env,
     bluff_body, nothing,
     time_traj,
@@ -493,7 +489,7 @@ fig, ax = create_aquarium_figure(;
 )
 lines!(ax, time_traj, fluid_energy_traj, label="Fluid Energy", linewidth=2)
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_energy_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_energy_$(floor(Int, reynolds_number))re.png"), fig)
 
 #############################################################################################
 ## Plot fluid pressure norms over time
@@ -515,9 +511,9 @@ fig, ax = create_aquarium_figure(;
 )
 lines!(ax, time_traj, fluid_pressure_norm_traj, label="Pressure Norm", linewidth=2)
 display(fig)
-save(joinpath(vis_dir, "freestream_disc_pressure_norm_$(floor(Int, reynolds_number))re.png"), fig)
+maybe_save(joinpath(vis_dir, "freestream_disc_pressure_norm_$(floor(Int, reynolds_number))re.png"), fig)
 
 println("\n" * "="^80)
 println("Simulation and visualization complete!")
-println("Results saved to: ", vis_dir)
+SAVE_FIGURES && println("Results saved to: ", vis_dir)
 println("="^80)

--- a/examples/fluid_examples/lid_cavity_flow_example.jl
+++ b/examples/fluid_examples/lid_cavity_flow_example.jl
@@ -78,7 +78,7 @@ fluid_sim_data = simulate_fluid(fluid_env, fluid_state_0, final_time;
 )
 
 save_file = data_file("lid_cavity_flow.jld2")
-jldsave(save_file;
+maybe_jldsave(save_file;
     fluid_sim_data
 );
 
@@ -86,8 +86,7 @@ jldsave(save_file;
 ## Import sim results
 #############################################################################################
 
-data = load(data_file("lid_cavity_flow.jld2"))
-fluid_sim_data = data["fluid_sim_data"]
+# fluid_sim_data is already in memory from the simulation above.
 t_traj = fluid_sim_data[:t_traj]
 fluid_velocity_traj = fluid_sim_data[:fluid_velocity_traj]
 fluid_pressure_traj = fluid_sim_data[:fluid_pressure_traj]
@@ -139,7 +138,7 @@ plot_streamlines!(fig, ax,
 display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_streamlines_animation.mp4")
-animate_streamlines(fig, ax,
+animate_if_enabled(animate_streamlines, fig, ax,
     fluid_env,
     nothing, nothing,
     t_traj,
@@ -176,7 +175,7 @@ plot_vorticity_field!(fig, ax,
 display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_vorticity_animation.mp4")
-animate_vorticity_field(fig, ax,
+animate_if_enabled(animate_vorticity_field, fig, ax,
     fluid_env,
     nothing, nothing,
     t_traj,
@@ -220,7 +219,7 @@ plot_velocity_field!(fig, ax,
 display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_velocity_field_animation.mp4")
-animate_velocity_field(fig, ax,
+animate_if_enabled(animate_velocity_field, fig, ax,
     fluid_env,
     nothing, nothing,
     t_traj,
@@ -262,7 +261,7 @@ plot_pressure_field!(fig, ax,
 display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_pressure_field_animation.mp4")
-animate_pressure_field(fig, ax,
+animate_if_enabled(animate_pressure_field, fig, ax,
     fluid_env,
     nothing, nothing,
     t_traj,

--- a/examples/fluid_examples/lid_cavity_flow_example.jl
+++ b/examples/fluid_examples/lid_cavity_flow_example.jl
@@ -135,7 +135,7 @@ plot_streamlines!(fig, ax,
     [], [];
     density=50
 )
-display(fig)
+maybe_display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_streamlines_animation.mp4")
 animate_if_enabled(animate_streamlines, fig, ax,
@@ -172,7 +172,7 @@ plot_vorticity_field!(fig, ax,
     min_threshold=-5.0,
     max_threshold=5.0
 )
-display(fig)
+maybe_display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_vorticity_animation.mp4")
 animate_if_enabled(animate_vorticity_field, fig, ax,
@@ -216,7 +216,7 @@ plot_velocity_field!(fig, ax,
     tipcolor=logocolors.blue,
     shaftcolor=logocolors.blue,
 )
-display(fig)
+maybe_display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_velocity_field_animation.mp4")
 animate_if_enabled(animate_velocity_field, fig, ax,
@@ -258,7 +258,7 @@ plot_pressure_field!(fig, ax,
     [], [];
 
 )
-display(fig)
+maybe_display(fig)
 
 save_path = joinpath(vis_dir, "lid_cavity_pressure_field_animation.mp4")
 animate_if_enabled(animate_pressure_field, fig, ax,

--- a/examples/fsi_examples/rexeel_c_start.jl
+++ b/examples/fsi_examples/rexeel_c_start.jl
@@ -302,8 +302,8 @@ vlines!(ax_ctrl, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_ctrl, position=:rt)
 display(fig_ctrl)
-save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
-println("Control input plot saved.")
+maybe_save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
+SAVE_FIGURES && println("Control input plot saved.")
 
 #############################################################################################
 ## Simulate solid system only (no fluid)
@@ -382,8 +382,8 @@ vlines!(ax_solid_joints, [T_prep + T_prop], color=:gray, linestyle=:dash, linewi
 
 axislegend(ax_solid_joints, position=:rt)
 display(fig_solid_joints)
-save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
-println("Solid joint angles plot saved.")
+maybe_save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
+SAVE_FIGURES && println("Solid joint angles plot saved.")
 
 # Animate solid system
 fig_solid, ax_solid = create_aquarium_figure(;
@@ -402,7 +402,7 @@ display(fig_solid)
 
 clear_aquarium_axis!(ax_solid)
 save_path_solid = joinpath(vis_dir, "solid_animation.mp4")
-animate_solid_systems(fig_solid, ax_solid,
+animate_if_enabled(animate_solid_systems, fig_solid, ax_solid,
     [rexeel],
     solid_time_traj,
     [solid_midpoint_state_traj],
@@ -410,7 +410,7 @@ animate_solid_systems(fig_solid, ax_solid,
     framerate=20,
     timescale=1.0,
 )
-println("Solid animation saved to: $save_path_solid")
+SAVE_ANIMATIONS && println("Solid animation saved to: $save_path_solid")
 
 #############################################################################################
 ## Initialize aquarium state
@@ -459,19 +459,15 @@ println("\nSimulation complete!")
 
 # Save simulation data
 save_file = data_file("rexeel_c_start.jld2")
-jldsave(save_file; trajectories)
-println("Results saved to: ", save_file)
+maybe_jldsave(save_file; trajectories)
+SAVE_DATA && println("Results saved to: ", save_file)
 println()
 
 #############################################################################################
 ## Load and process simulation data
 #############################################################################################
 
-# Load simulation data
-
-load_file = data_file("rexeel_c_start.jld2")
-data = load(load_file)
-trajectories = data["trajectories"]
+# trajectories is already in memory from the simulation above.
 
 # Extract trajectories
 time_traj = trajectories[:time_traj]
@@ -528,7 +524,7 @@ end
 
 axislegend(ax_joint, position=:rt)
 display(joint_fig)
-save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
+maybe_save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
 
 #############################################################################################
 ## Plot center of mass trajectory
@@ -575,7 +571,7 @@ scatter!(ax_com, [com_x[1]], [com_y[1]], color=logocolors[3], markersize=15, lab
 scatter!(ax_com, [com_x[end]], [com_y[end]], color=logocolors[2], markersize=15, label="End")
 axislegend(ax_com, position=:lb)
 display(com_fig)
-save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
+maybe_save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
 
 # Print displacement
 println("Vertical displacement: $(com_y[end] - com_y[1]) cm")
@@ -635,7 +631,7 @@ vlines!(ax_com_vel, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1
 
 axislegend(ax_com_vel, position=:lt)
 display(com_vel_fig)
-save(joinpath(vis_dir, "com_velocity.png"), com_vel_fig)
+maybe_save(joinpath(vis_dir, "com_velocity.png"), com_vel_fig)
 
 # Print velocity statistics
 println("Peak velocity magnitude: $(maximum(com_v_mag)) cm/s")
@@ -726,9 +722,9 @@ vlines!(ax_orient, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_orient, position=:rt)
 display(orient_fig)
-save(joinpath(vis_dir, "swimmer_orientation.png"), orient_fig)
+maybe_save(joinpath(vis_dir, "swimmer_orientation.png"), orient_fig)
 
-println("Orientation plot saved.")
+SAVE_FIGURES && println("Orientation plot saved.")
 println("  Initial head angle: $(rad2deg(head_angle[1]))°")
 println("  Final head angle: $(rad2deg(head_angle[end]))°")
 println("  Total head rotation: $(rad2deg(head_angle[end] - head_angle[1]))°")
@@ -768,11 +764,11 @@ plot_velocity_field!(fig, ax,
     smooth_sigma=3.0
 )
 display(fig)
-save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
+maybe_save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
 
 # Animate velocity field
 save_path = joinpath(vis_dir, "rexeel_velocity_animation.mp4")
-animate_velocity_field(fig, ax,
+animate_if_enabled(animate_velocity_field, fig, ax,
     fluid_env,
     nothing, rexeel,
     time_traj,
@@ -822,11 +818,11 @@ plot_vorticity_field!(fig, ax,
 )
 
 display(fig)
-save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
+maybe_save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
 
 # Animate vorticity field
 save_path = joinpath(vis_dir, "rexeel_vorticity_animation.mp4")
-animate_vorticity_field(fig, ax,
+animate_if_enabled(animate_vorticity_field, fig, ax,
     fluid_env,
     nothing, rexeel,
     time_traj,
@@ -842,7 +838,7 @@ animate_vorticity_field(fig, ax,
 )
 
 println("Visualization complete!")
-println("Results saved to: ", vis_dir)
+(SAVE_FIGURES || SAVE_ANIMATIONS) && println("Results saved to: ", vis_dir)
 
 com_x_N = com_x[end]
 com_y_N = com_y[end]

--- a/examples/fsi_examples/rexeel_c_start.jl
+++ b/examples/fsi_examples/rexeel_c_start.jl
@@ -301,7 +301,7 @@ vlines!(ax_ctrl, [T_prep], color=:gray, linestyle=:dash, linewidth=1)
 vlines!(ax_ctrl, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_ctrl, position=:rt)
-display(fig_ctrl)
+maybe_display(fig_ctrl)
 maybe_save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
 SAVE_FIGURES && println("Control input plot saved.")
 
@@ -381,7 +381,7 @@ vlines!(ax_solid_joints, [T_prep], color=:gray, linestyle=:dash, linewidth=1)
 vlines!(ax_solid_joints, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_solid_joints, position=:rt)
-display(fig_solid_joints)
+maybe_display(fig_solid_joints)
 maybe_save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
 SAVE_FIGURES && println("Solid joint angles plot saved.")
 
@@ -398,7 +398,7 @@ fig_solid, ax_solid = create_aquarium_figure(;
 )
 
 plot_solid_systems!(fig_solid, ax_solid, [rexeel], [solid_midpoint_state_traj[end]])
-display(fig_solid)
+maybe_display(fig_solid)
 
 clear_aquarium_axis!(ax_solid)
 save_path_solid = joinpath(vis_dir, "solid_animation.mp4")
@@ -523,7 +523,7 @@ for i in 1:n_joints
 end
 
 axislegend(ax_joint, position=:rt)
-display(joint_fig)
+maybe_display(joint_fig)
 maybe_save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
 
 #############################################################################################
@@ -570,7 +570,7 @@ lines!(ax_com, com_x, com_y, color=logocolors[1], linewidth=2, label="Center of 
 scatter!(ax_com, [com_x[1]], [com_y[1]], color=logocolors[3], markersize=15, label="Start")
 scatter!(ax_com, [com_x[end]], [com_y[end]], color=logocolors[2], markersize=15, label="End")
 axislegend(ax_com, position=:lb)
-display(com_fig)
+maybe_display(com_fig)
 maybe_save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
 
 # Print displacement
@@ -630,7 +630,7 @@ vlines!(ax_com_vel, [T_prep], color=:gray, linestyle=:dash, linewidth=1)
 vlines!(ax_com_vel, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_com_vel, position=:lt)
-display(com_vel_fig)
+maybe_display(com_vel_fig)
 maybe_save(joinpath(vis_dir, "com_velocity.png"), com_vel_fig)
 
 # Print velocity statistics
@@ -721,7 +721,7 @@ vlines!(ax_orient, [T_prep], color=:gray, linestyle=:dash, linewidth=1)
 vlines!(ax_orient, [T_prep + T_prop], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_orient, position=:rt)
-display(orient_fig)
+maybe_display(orient_fig)
 maybe_save(joinpath(vis_dir, "swimmer_orientation.png"), orient_fig)
 
 SAVE_FIGURES && println("Orientation plot saved.")
@@ -763,7 +763,7 @@ plot_velocity_field!(fig, ax,
     smooth=true,
     smooth_sigma=3.0
 )
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
 
 # Animate velocity field
@@ -817,7 +817,7 @@ plot_vorticity_field!(fig, ax,
     smooth_sigma=4.0
 )
 
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
 
 # Animate vorticity field

--- a/examples/fsi_examples/rexeel_forward_swimming.jl
+++ b/examples/fsi_examples/rexeel_forward_swimming.jl
@@ -271,7 +271,7 @@ end
 vlines!(ax_ctrl, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_ctrl, position=:rt)
-display(fig_ctrl)
+maybe_display(fig_ctrl)
 maybe_save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
 SAVE_FIGURES && println("Control input plot saved.")
 
@@ -350,7 +350,7 @@ end
 vlines!(ax_solid_joints, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_solid_joints, position=:rt)
-display(fig_solid_joints)
+maybe_display(fig_solid_joints)
 maybe_save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
 SAVE_FIGURES && println("Solid joint angles plot saved.")
 
@@ -367,7 +367,7 @@ fig_solid, ax_solid = create_aquarium_figure(;
 )
 
 plot_solid_systems!(fig_solid, ax_solid, [rexeel], [solid_midpoint_state_traj[end]])
-display(fig_solid)
+maybe_display(fig_solid)
 
 clear_aquarium_axis!(ax_solid)
 save_path_solid = joinpath(vis_dir, "solid_animation.mp4")
@@ -492,7 +492,7 @@ for i in 1:n_joints
 end
 
 axislegend(ax_joint, position=:rt)
-display(joint_fig)
+maybe_display(joint_fig)
 maybe_save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
 
 #############################################################################################
@@ -532,7 +532,7 @@ lines!(ax_com, com_x, com_y, color=logocolors[1], linewidth=2, label="Center of 
 scatter!(ax_com, [com_x[1]], [com_y[1]], color=logocolors[3], markersize=15, label="Start")
 scatter!(ax_com, [com_x[end]], [com_y[end]], color=logocolors[2], markersize=15, label="End")
 axislegend(ax_com, position=:lb)
-display(com_fig)
+maybe_display(com_fig)
 maybe_save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
 
 # Print displacement
@@ -577,7 +577,7 @@ lines!(ax_vel, time_traj, com_speed, color=logocolors[3], linewidth=2, label="sp
 vlines!(ax_vel, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_vel, position=:rt)
-display(vel_fig)
+maybe_display(vel_fig)
 maybe_save(joinpath(vis_dir, "com_velocity.png"), vel_fig)
 
 println("Max COM speed: $(maximum(com_speed)) cm/s")
@@ -616,7 +616,7 @@ plot_velocity_field!(fig, ax,
     smooth=true,
     smooth_sigma=3.0
 )
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
 
 # Animate velocity field
@@ -670,7 +670,7 @@ plot_vorticity_field!(fig, ax,
     smooth_sigma=4.0
 )
 
-display(fig)
+maybe_display(fig)
 maybe_save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
 
 # Animate vorticity field

--- a/examples/fsi_examples/rexeel_forward_swimming.jl
+++ b/examples/fsi_examples/rexeel_forward_swimming.jl
@@ -272,8 +272,8 @@ vlines!(ax_ctrl, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_ctrl, position=:rt)
 display(fig_ctrl)
-save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
-println("Control input plot saved.")
+maybe_save(joinpath(vis_dir, "control_inputs.png"), fig_ctrl)
+SAVE_FIGURES && println("Control input plot saved.")
 
 #############################################################################################
 ## Simulate solid system only (no fluid)
@@ -351,8 +351,8 @@ vlines!(ax_solid_joints, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_solid_joints, position=:rt)
 display(fig_solid_joints)
-save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
-println("Solid joint angles plot saved.")
+maybe_save(joinpath(vis_dir, "solid_joint_angles.png"), fig_solid_joints)
+SAVE_FIGURES && println("Solid joint angles plot saved.")
 
 # Animate solid system
 fig_solid, ax_solid = create_aquarium_figure(;
@@ -371,7 +371,7 @@ display(fig_solid)
 
 clear_aquarium_axis!(ax_solid)
 save_path_solid = joinpath(vis_dir, "solid_animation.mp4")
-animate_solid_systems(fig_solid, ax_solid,
+animate_if_enabled(animate_solid_systems, fig_solid, ax_solid,
     [rexeel],
     solid_time_traj,
     [solid_midpoint_state_traj],
@@ -379,7 +379,7 @@ animate_solid_systems(fig_solid, ax_solid,
     framerate=20,
     timescale=1.0,
 )
-println("Solid animation saved to: $save_path_solid")
+SAVE_ANIMATIONS && println("Solid animation saved to: $save_path_solid")
 
 #############################################################################################
 ## Initialize aquarium state
@@ -428,18 +428,15 @@ println("\nSimulation complete!")
 
 # Save simulation data
 save_file = data_file("rexeel_forward_swimming.jld2")
-jldsave(save_file; trajectories)
-println("Results saved to: ", save_file)
+maybe_jldsave(save_file; trajectories)
+SAVE_DATA && println("Results saved to: ", save_file)
 println()
 
 #############################################################################################
 ## Load and process simulation data
 #############################################################################################
 
-# Load simulation data
-load_file = data_file("rexeel_forward_swimming.jld2")
-data = load(load_file)
-trajectories = data["trajectories"]
+# trajectories is already in memory from the simulation above.
 
 # Extract trajectories
 time_traj = trajectories[:time_traj]
@@ -496,7 +493,7 @@ end
 
 axislegend(ax_joint, position=:rt)
 display(joint_fig)
-save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
+maybe_save(joinpath(vis_dir, "joint_angles.png"), joint_fig)
 
 #############################################################################################
 ## Plot center of mass trajectory
@@ -536,7 +533,7 @@ scatter!(ax_com, [com_x[1]], [com_y[1]], color=logocolors[3], markersize=15, lab
 scatter!(ax_com, [com_x[end]], [com_y[end]], color=logocolors[2], markersize=15, label="End")
 axislegend(ax_com, position=:lb)
 display(com_fig)
-save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
+maybe_save(joinpath(vis_dir, "com_trajectory.png"), com_fig)
 
 # Print displacement
 println("Forward (X) displacement: $(com_x[end] - com_x[1]) cm")
@@ -581,7 +578,7 @@ vlines!(ax_vel, [T_ramp], color=:gray, linestyle=:dash, linewidth=1)
 
 axislegend(ax_vel, position=:rt)
 display(vel_fig)
-save(joinpath(vis_dir, "com_velocity.png"), vel_fig)
+maybe_save(joinpath(vis_dir, "com_velocity.png"), vel_fig)
 
 println("Max COM speed: $(maximum(com_speed)) cm/s")
 println("Final forward velocity: $(com_vx[end]) cm/s")
@@ -620,11 +617,11 @@ plot_velocity_field!(fig, ax,
     smooth_sigma=3.0
 )
 display(fig)
-save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
+maybe_save(joinpath(vis_dir, "rexeel_velocity_final.png"), fig)
 
 # Animate velocity field
 save_path = joinpath(vis_dir, "rexeel_velocity_animation.mp4")
-animate_velocity_field(fig, ax,
+animate_if_enabled(animate_velocity_field, fig, ax,
     fluid_env,
     nothing, rexeel,
     time_traj,
@@ -674,11 +671,11 @@ plot_vorticity_field!(fig, ax,
 )
 
 display(fig)
-save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
+maybe_save(joinpath(vis_dir, "rexeel_vorticity_final.png"), fig)
 
 # Animate vorticity field
 save_path = joinpath(vis_dir, "rexeel_vorticity_animation.mp4")
-animate_vorticity_field(fig, ax,
+animate_if_enabled(animate_vorticity_field, fig, ax,
     fluid_env,
     nothing, rexeel,
     time_traj,
@@ -694,4 +691,4 @@ animate_vorticity_field(fig, ax,
 )
 
 println("Visualization complete!")
-println("Results saved to: ", vis_dir)
+(SAVE_FIGURES || SAVE_ANIMATIONS) && println("Results saved to: ", vis_dir)

--- a/examples/solid_examples/actuated_pendulum_example.jl
+++ b/examples/solid_examples/actuated_pendulum_example.jl
@@ -136,7 +136,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect = true,
 )
 plot_solid_systems!(fig, ax, [pendulum], [midpoint_state_traj[end]])
-display(fig)
+maybe_display(fig)
 
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "actuated_pendulum_animation.mp4")
@@ -173,4 +173,4 @@ lines!(ax_angle, time_control, rad2deg.(desired_angles),
     color = logocolors[2], linewidth = 2, linestyle = :dash, label = "Target θ")
 
 axislegend(ax_angle, position = :rt)
-display(angle_fig)
+maybe_display(angle_fig)

--- a/examples/solid_examples/actuated_pendulum_example.jl
+++ b/examples/solid_examples/actuated_pendulum_example.jl
@@ -140,7 +140,7 @@ display(fig)
 
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "actuated_pendulum_animation.mp4")
-animate_solid_systems(fig, ax,
+animate_if_enabled(animate_solid_systems, fig, ax,
     [pendulum],
     time_traj,
     [midpoint_state_traj],

--- a/examples/solid_examples/double_pendulum_example.jl
+++ b/examples/solid_examples/double_pendulum_example.jl
@@ -118,7 +118,7 @@ energy_fig, energy_ax = create_aquarium_figure(;
 )
 
 lines!(energy_ax, time_traj, total_energy_traj, label="Total Energy", linewidth=2)
-display(energy_fig)
+maybe_display(energy_fig)
 
 # Save energy plot
 energy_save_path = joinpath(vis_dir, "double_pendulum_energy.png")

--- a/examples/solid_examples/double_pendulum_example.jl
+++ b/examples/solid_examples/double_pendulum_example.jl
@@ -122,8 +122,8 @@ display(energy_fig)
 
 # Save energy plot
 energy_save_path = joinpath(vis_dir, "double_pendulum_energy.png")
-save(energy_save_path, energy_fig)
-println("Energy plot saved to: $energy_save_path")
+maybe_save(energy_save_path, energy_fig)
+SAVE_FIGURES && println("Energy plot saved to: $energy_save_path")
 
 # Calculate energy drift
 initial_energy = total_energy_traj[1]
@@ -160,7 +160,7 @@ plot_solid_systems!(fig, ax, [double_pendulum], [midpoint_state_traj[2]])
 # Create animation
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "double_pendulum_animation.mp4")
-animate_solid_systems(
+animate_if_enabled(animate_solid_systems, 
     fig,
     ax,
     [double_pendulum],

--- a/examples/solid_examples/eel_example.jl
+++ b/examples/solid_examples/eel_example.jl
@@ -146,7 +146,7 @@ aquarium_fig, aquarium_ax = create_aquarium_figure(resolution=resolution,
     fontsize=fontsize
 )
 plot_solid_systems!(aquarium_fig, aquarium_ax, [eel], [midpoint_state_traj[end]])
-display(aquarium_fig)
+maybe_display(aquarium_fig)
 
 # Animate (subsample for faster rendering)
 clear_aquarium_axis!(aquarium_ax)

--- a/examples/solid_examples/eel_example.jl
+++ b/examples/solid_examples/eel_example.jl
@@ -151,7 +151,7 @@ display(aquarium_fig)
 # Animate (subsample for faster rendering)
 clear_aquarium_axis!(aquarium_ax)
 save_path = joinpath(vis_dir, "eel_animation.mp4")
-animate_solid_systems(aquarium_fig, aquarium_ax,
+animate_if_enabled(animate_solid_systems, aquarium_fig, aquarium_ax,
     [eel],
     time_traj,
     [midpoint_state_traj],

--- a/examples/solid_examples/pendulum_example.jl
+++ b/examples/solid_examples/pendulum_example.jl
@@ -117,7 +117,7 @@ plot_solid_systems!(fig, ax, [pendulum], [midpoint_state_traj[end]])
 
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "pendulum_animation.mp4")
-animate_solid_systems(fig, ax,
+animate_if_enabled(animate_solid_systems, fig, ax,
     [pendulum],
     time_traj,
     [midpoint_state_traj],

--- a/examples/solid_examples/rexeel_example.jl
+++ b/examples/solid_examples/rexeel_example.jl
@@ -172,7 +172,7 @@ display(fig)
 
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "rexeel_animation.mp4")
-animate_solid_systems(fig, ax,
+animate_if_enabled(animate_solid_systems, fig, ax,
     [rexeel],
     time_traj,
     [midpoint_state_traj],

--- a/examples/solid_examples/rexeel_example.jl
+++ b/examples/solid_examples/rexeel_example.jl
@@ -168,7 +168,7 @@ fig, ax = create_aquarium_figure(;
     use_data_aspect=true
 )
 plot_solid_systems!(fig, ax, [rexeel], [midpoint_state_traj[end]])
-display(fig)
+maybe_display(fig)
 
 clear_aquarium_axis!(ax)
 save_path = joinpath(vis_dir, "rexeel_animation.mp4")
@@ -231,4 +231,4 @@ lines!(ax_joint, time_control, rad2deg.(desired_φ2),
     color=logocolors[2], linewidth=2, linestyle=:dash, label="Desired φ₂")
 
 axislegend(ax_joint, position=:rt)
-display(joint_fig)
+maybe_display(joint_fig)

--- a/test/example_smoke_tests.jl
+++ b/test/example_smoke_tests.jl
@@ -50,6 +50,10 @@
             # No example reads back data it wrote in the same run. That round trip
             # only worked because saving was unconditional.
             @test !occursin(r"\bload\(", source)
+
+            # Figures are opened through the display guard, so a headless run --
+            # cluster, CI, over SSH -- does not try to open a viewer.
+            @test !occursin(r"(?<!maybe_)\bdisplay\(", source)
         end
     end
 end

--- a/test/example_smoke_tests.jl
+++ b/test/example_smoke_tests.jl
@@ -5,10 +5,10 @@
     # need a display. That makes them the weakest-verified surface in the
     # repository: all thirteen can be edited wrongly while the suite stays green.
     #
-    # This is a floor, not proof. It catches syntax damage and stale references to
-    # the removed path constants, which is the failure mode a bulk edit actually
-    # produces. It does not catch a script that parses fine and computes the wrong
-    # thing.
+    # These checks are a floor, not proof. They catch syntax damage, stale
+    # references to removed constants, and artifact calls that escaped a guard --
+    # the failure modes a bulk edit actually produces. They do not catch a script
+    # that parses fine and computes the wrong thing.
 
     examples_root = joinpath(pkgdir(Aquarium), "examples")
     scripts = String[]
@@ -36,6 +36,20 @@
                             "Aquarium.EXAMPLES_DIR", "Aquarium.TEST_DIR")
                 @test !occursin(removed, source)
             end
+
+            # Every artifact-producing call goes through a guard, so a default run
+            # writes nothing. A missed call site is exactly what a bulk edit leaves
+            # behind, and it would silently reintroduce unconditional file output.
+            @test !occursin(r"(?<!maybe_)\bsave\(", source)
+            @test !occursin(r"(?<!maybe_)\bjldsave\(", source)
+
+            animate_calls = [m.match for m in eachmatch(r"\banimate_[a-z_]+\(", source)]
+            unguarded = filter(c -> c != "animate_if_enabled(", animate_calls)
+            @test isempty(unguarded)
+
+            # No example reads back data it wrote in the same run. That round trip
+            # only worked because saving was unconditional.
+            @test !occursin(r"\bload\(", source)
         end
     end
 end


### PR DESCRIPTION
Closes #16. Part of #3. **HITL — review, not auto-merge.**

**Stacked on #15** (`issue-6-filesystem`), which introduces the shared example setup this builds on. Base is that branch, so this diff shows only the artifact-gating change. Merge #15 first.

## What changed

Running any example wrote to disk unconditionally — 24 figure saves, 6 data saves, 19 animations. Now opt-in, off by default:

```
AQUARIUM_SAVE_DATA        .jld2 simulation data
AQUARIUM_SAVE_FIGURES     static figures
AQUARIUM_SAVE_ANIMATIONS  animations
AQUARIUM_SAVE_ALL         all three
```

A default run computes, plots, and writes nothing. Flags are read once at setup so a run is internally consistent.

## Design notes worth reviewing

**Guards live in wrapper functions, not call sites.** `maybe_save`, `maybe_jldsave`, and `animate_if_enabled(f, args...)` make all 49 edits single-token substitutions. Multi-line `animate_*` calls keep their argument lists and closing parens untouched — wrapping them in `if` blocks by regex would have required paren matching across line breaks, which is exactly how a bulk edit silently corrupts a script.

**The path helpers stopped calling `mkpath`.** They created directories on every call, so a default run would still have littered empty directories even with every write guarded. Directories are now made by the writers, when they write.

**`save`/`jldsave` are deliberately not imported into `common.jl`.** It's included into `Main`, so an explicit `using FileIO: save` would take precedence over the `save` each example gets from `using Aquarium.CairoMakie` — and these are Makie figures. Julia resolves globals in function bodies at call time, so leaving them unimported means the wrappers use the same binding the examples always did. This was a live bug in the first draft.

## Two things that need your judgement

**`immersed_boundary_comparison.jl` now holds more in memory.** Five of the six disk round trips were redundant — save, then immediately reload variables still in memory, a REPL-cell-workflow artifact. This one was real: two loops, the second reading from disk what the first wrote. Results now pass through an in-memory `Dict` keyed by case label, which means **all four cases' trajectories are held at once rather than one at a time.** Peak memory rises. If that's a problem for the grid sizes you actually run, merging the two loops would fix it at the cost of a larger structural change.

**17 `println`s were guarded**, each of which announced `"Results saved to: …"` and would otherwise name files that were never written.

## Verification

```
Pkg.test() → 2378 passed, 0 failed, 4m20.0s
```

Up from 2326; the 52 new passes are guard assertions in the smoke test — every artifact call is inside a guard, and no script loads data it wrote.

All 14 example scripts parse. **No example was executed**, per instruction. So acceptance criterion 1 — that a default run truly writes nothing — rests on construction and static checks, not observation. That is the honest limit of this verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)