### PR TITLE
Compare divergence residual with a tolerance, not exact equality

### DIFF
--- a/src/fluid/fvm_operators.jl
+++ b/src/fluid/fvm_operators.jl
@@ -295,7 +295,16 @@ end
     v = vcat(2 .* ones(grid.n_vx), 1.5 .* ones(grid.n_vy))
 
     @test size(divergence) == (grid.n_cell-4, grid.n_vx + grid.n_vy)
-    @test divergence * v == zeros(grid.n_cell-4)
+
+    # v is uniform and therefore divergence-free, so this is mathematically zero.
+    # It is computed as a sparse matrix-vector product summing four terms of order
+    # v/dx ~ 1, so the result carries roundoff of order eps() -- whether it lands
+    # on exact zero depends on how the arithmetic is associated. It does on Julia
+    # 1.10 and does not on 1.13, where the observed residual is 2.8e-17, itself an
+    # order of magnitude below eps(). A genuine sign or scaling error in the
+    # operator would be order 1, so 100*eps() leaves ~13 orders of margin for
+    # catching real defects while tolerating roundoff.
+    @test isapprox(divergence * v, zeros(grid.n_cell-4); atol = 100 * eps(Float64))
 end
 
 @testitem "3×4 Grid Divergence" begin
@@ -309,5 +318,7 @@ end
     v = vcat(2 .* ones(grid.n_vx), 1.5 .* ones(grid.n_vy))
 
     @test size(divergence) == (grid.n_cell-4, grid.n_vx + grid.n_vy)
-    @test divergence * v == zeros(grid.n_cell-4)
+
+    # See the 4x3 case above. Observed residual on Julia 1.13 is 5.6e-17.
+    @test isapprox(divergence * v, zeros(grid.n_cell-4); atol = 100 * eps(Float64))
 end


### PR DESCRIPTION
Closes #13.

Two tests asserted a computed divergence is **bitwise** equal to zero:

```julia
@test divergence * v == zeros(grid.n_cell-4)
```

The field is uniform and therefore divergence-free, so this is mathematically zero — but it's computed as a sparse matvec summing four terms of order `v/dx ~ 1`, so the result carries roundoff of order `eps()`. Whether it lands on exact zero depends on how the arithmetic is associated. It does on 1.10.11 and 1.12.6; it doesn't on 1.13.0-rc2, where CI observed `2.8e-17` and `5.6e-17`. **The operators are correct; the assertions weren't.**

```julia
@test isapprox(divergence * v, zeros(grid.n_cell-4); atol = 100 * eps(Float64))
```

`100 * eps(Float64)` = `2.2e-14` — about **400× the largest observed residual**, and ~13 orders below the order-1 error a genuine sign or scaling mistake would produce. The comment records where the number comes from, not just what it is.

## I checked for the same defect elsewhere

Of ~90 exact-equality assertions in `src/`, **only these two are at risk**. Every other one compares entries that are *structurally* zero — sparsity patterns, untouched boundary rows, empty systems — where no arithmetic occurs and exact zero is correct. That matches CI, where only these two failed.

## Scope of verification

Verified non-regressing on 1.12.6, where the residual is exactly `0.0` and both the old and new assertions pass.

**Not reproduced locally on 1.13.0-rc2.** The evidence for the fix is CI's *measured* residuals against a tolerance 400× larger — arithmetic on observed numbers, not estimation. Since the prerelease channel was removed from the CI matrix in #14, nothing automated will exercise this path again; that's a deliberate trade, noted here so it isn't a surprise later.

Operators unchanged; the diff touches assertions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)